### PR TITLE
ci: Add PyPI release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Release
+
+on:
+  release:
+    types: [ published ]
+
+jobs:
+  test:
+    name: Test
+    uses: ./.github/workflows/test.yml
+
+  package:
+    name: Package
+    uses: ./.github/workflows/package.yml
+
+  release:
+    name: Release
+    environment: release
+    needs: [ test, package ]
+    runs-on: ubuntu-22.04
+
+    permissions:
+      contents: write
+      id-token: write
+
+    steps:
+    - name: Download build artifacts
+      uses: actions/download-artifact@v4
+
+    - name: Upload release assets
+      uses: softprops/action-gh-release@v2
+      with:
+        files: |
+          dist/*.whl
+
+    - name: Publish package to PyPI
+      uses: pypa/gh-action-pypi-publish@release/v1


### PR DESCRIPTION
This commit adds a GitHub Actions CI workflow that tests and builds the Kconfiglib Python package and publishes it to PyPI when a new release is published.