### PR TITLE
ci: test: Run macOS Python 3.7 test on macos-12

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -46,7 +46,7 @@ jobs:
           builder: ubuntu-20.04
         - python: '3.7'
           os: macOS
-          builder: macos-13
+          builder: macos-12
         # - python: '3.7'
         #   os: Windows
         #   builder: windows-2019


### PR DESCRIPTION
This commit updates the Python test workflow to run the macOS Python 3.7 case on the GitHub runner `macos-12` image, instead of the `macos-13` image because it is (erroneously) missing the ncurses installation as of the version 20240930.147.