### PR TITLE
ci: remove old python version and phased out GH runners

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -33,7 +33,7 @@ jobs:
         # Python 3.9
         - python: '3.9'
           os: Linux
-          builder: ubuntu-20.04
+          builder: ubuntu-22.04
         - python: '3.9'
           os: macOS
           builder: macos-13


### PR DESCRIPTION
- Python versions < 3.8 are all EOL
- Ubuntu 20.04 GH runner is not available anymore

@pillo79


Should we also update setup.py file? @pdgendt, thoughts?