### PR TITLE
Support conditional dependencies using "depends on A if B".

### DIFF
--- a/kconfiglib.py
+++ b/kconfiglib.py
@@ -3117,6 +3117,36 @@ class Kconfig(object):
 
         return expr
 
+    def _parse_depends(self):
+        # Parses conditional dependencies with syntax "depends on <expr> if <condition>"
+        # Returns the appropriate expression that represents the conditional dependency
+
+        # Parse the main dependency expression
+        main_expr = self._parse_expr(True)
+
+        # Check if there's an optional "if <condition>" clause
+        if self._check_token(_T_IF):
+            # Parse the condition expression
+            condition = self._parse_expr(True)
+
+            # Check for end of line
+            if self._tokens[self._tokens_i] is not None:
+                self._trailing_tokens_error()
+
+            # Create conditional dependency: "depends on A if B" becomes "!B || A"
+            # This means: if B is false, the dependency is satisfied (y)
+            #             if B is true, the dependency becomes A
+            return self._make_or(
+                (NOT, condition),
+                main_expr
+            )
+        else:
+            # No conditional clause, just return the main expression
+            if self._tokens[self._tokens_i] is not None:
+                self._trailing_tokens_error()
+
+            return main_expr
+
     def _parse_props(self, node):
         # Parses and adds properties to the MenuNode 'node' (type, 'prompt',
         # 'default's, etc.) Properties are later copied up to symbols and
@@ -3152,7 +3182,7 @@ class Kconfig(object):
                     self._parse_error("expected 'on' after 'depends'")
 
                 node.dep = self._make_and(node.dep,
-                                          self._expect_expr_and_eol())
+                                          self._parse_depends())
 
             elif t0 is _T_HELP:
                 self._parse_help(node)


### PR DESCRIPTION
Extend the "depends on" syntax to support conditional dependencies using "... if <B>". While functionally equivalent to "depends on !B || A", "depends on A if B" is much more readable.

This change is implemented by converting the "A if B" syntax into the "!B || A" syntax during "depends on" token processing.