### PR TITLE
guiconfig: fix importing sys being used

### DIFF
--- a/guiconfig.py
+++ b/guiconfig.py
@@ -55,6 +55,7 @@ $srctree is supported through Kconfiglib.
 import errno
 import os
 import re
+import sys
 
 from tkinter import *
 import tkinter.ttk as ttk


### PR DESCRIPTION
Since commit ffb54593b899c42fe70e55d26e02d4cd4a9ca53d, sys is being used to detect platform for dark mode
sys has been removed from imports in the commit
24aef157aead07f813f874f43ee471b057e622cb