### PR TITLE
kconfiglib: keep the GC out of the way while parsing

### DIFF
--- a/kconfiglib.py
+++ b/kconfiglib.py
@@ -541,6 +541,7 @@ For bug reports, suggestions, and questions, please open a ticket on the GitHub
 page.
 """
 import errno
+import gc
 import importlib
 import os
 import re
@@ -933,8 +934,19 @@ class Kconfig(object):
           Other exceptions besides EnvironmentError and KconfigError are still
           propagated when suppress_traceback is True.
         """
+        # Parsing builds a big graph of long-lived objects, and the cyclic
+        # garbage collector responds by running ever more expensive full
+        # collections over it, hunting for cycles that are hardly ever there.
+        # Reference counting handles the temporary objects by itself, so keep
+        # the collector away until the tree is built, then let it look at
+        # everything once. That single pass keeps the next collection cheap.
+        gc_was_enabled = gc.isenabled()
+        gc.disable()
+
         try:
             self._init(filename, warn, warn_to_stderr, encoding)
+            if gc_was_enabled:
+                gc.collect()
         except (EnvironmentError, KconfigError) as e:
             if suppress_traceback:
                 cmd = sys.argv[0]  # Empty string if missing
@@ -945,6 +957,9 @@ class Kconfig(object):
                 # them here.
                 sys.exit(cmd + str(e).strip())
             raise
+        finally:
+            if gc_was_enabled:
+                gc.enable()
 
     def _init(self, filename, warn, warn_to_stderr, encoding):
         # See __init__()


### PR DESCRIPTION
## Summary

Parsing builds a large graph of objects that stays alive for as long as the `Kconfig` instance does — around 680,000 tracked objects for a big configuration tree. CPython's cyclic collector responds to a growing long-lived graph by running progressively more expensive collections, each one walking all of it looking for cycles that are essentially never there.

Reference counting already handles the short-lived objects, so this disables the collector for the duration of the parse and runs a single collection at the end, restoring the previous state in a `finally`. That one pass is also what keeps the first collection *after* parsing cheap, rather than leaving a backlog for the caller's next allocations to pay off.

## Performance

Two real trees, workload = parse → `write_config()` → `write_autoconf()`. Variants interleaved in fresh processes, median CPU time. Lower is better; an A-vs-A control puts the noise floor at ±0.3%.

- **Linux v5.4 x86_64** — 14,159 symbols, 14,671 menu nodes, 1,289 files
- **Zephyr** — 31,875 symbols, 47,369 menu nodes, 7,893 files

| Python | Linux v5.4 | Zephyr |
|---|---|---|
| 3.12.14 | 0.330 s → 0.307 s (**−6.8%**) | 0.999 s → 0.901 s (**−9.8%**) |
| 3.13.15 | 0.327 s → 0.314 s (**−3.8%**) | 0.974 s → 0.914 s (**−6.2%**) |
| 3.14.7 | 0.302 s → 0.286 s (**−5.3%**) | 0.952 s → 0.867 s (**−8.9%**) |

Collector activity over the same runs, before → after (gen-0/gen-1/gen-2 collection counts, and share of parse time spent in the collector):

| Python | Linux collections | Linux in-GC | Zephyr collections | Zephyr in-GC |
|---|---|---|---|---|
| 3.12.14 | 364/33/3 → 2/0/1 | 15.0% → 7.8% | 1042/94/7 → 8/0/1 | 18.3% → 9.8% |
| 3.13.15 | 127/12/1 → 1/0/1 | 11.3% → 7.7% | 365/33/3 → 3/0/1 | 15.7% → 9.7% |
| 3.14.7 | 127/12/1 → 1/0/1 | 10.8% → 6.2% | 364/33/3 → 3/0/1 | 14.7% → 7.1% |

What is left in the collector after the change is the single full collection this patch runs itself. The gain is smaller on 3.13 and 3.14, which raised the young-generation threshold from 700 to 2000 and reworked old-generation collection, already removing part of the overhead. Peak RSS is unchanged.

## Correctness

| Check | Result |
|---|---|
| Canonical dump of the whole parsed tree — every menu node with its prompt, dependencies and type, every symbol's value, visibility and direct dependencies, every choice, plus the warning list | byte-identical on both trees (12 MB for Linux, 131 MB for Zephyr) |
| `alldefconfig`, `allnoconfig`, `allyesconfig` and `allmodconfig` on every Linux v5.4 architecture | 100/100 comparisons identical, across all 25 arches |
| `testsuite.py` selftests | pass, before and after |

The Zephyr figures use Zephyr's vendored copy of this file, which carries local extensions (`configdefault` among them) that upstream does not parse. The change itself is byte-identical in both copies.
